### PR TITLE
Re-add support for v6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   global:
     - RACKET_DIR=~/racket
   matrix:
+    - RACKET_VERSION=6.3
     - RACKET_VERSION=6.4
     - RACKET_VERSION=6.5
     - RACKET_VERSION=6.6

--- a/doc-coverage/export-count.rkt
+++ b/doc-coverage/export-count.rkt
@@ -5,16 +5,15 @@
          module-num-undocumented-exports
          module-documentation-ratio)
 
-(require compose-app
-         "export-lists.rkt")
+(require "export-lists.rkt")
 
-(define module-num-exports (length .. module->all-exported-names))
+(define module-num-exports (compose length module->all-exported-names))
 
 (define module-num-documented-exports
-  (length .. module->documented-exported-names))
+  (compose length module->documented-exported-names))
 
 (define module-num-undocumented-exports
-  (length .. module->undocumented-exported-names))
+  (compose length module->undocumented-exported-names))
 
 (define (module-documentation-ratio mod)
   (/ (module-num-documented-exports mod)

--- a/doc-coverage/export-lists.rkt
+++ b/doc-coverage/export-lists.rkt
@@ -5,8 +5,7 @@
          module->undocumented-exported-names
          has-docs?)
 
-(require compose-app/fancy-app
-         scribble/xref
+(require scribble/xref
          setup/xref)
 
 
@@ -18,8 +17,9 @@
 (define (has-docs? mod binding)
   (and (xref-mod+binding->definition-tag mod binding) #t))
 
-(define phase-exports->names
-  (map first _ .. apply append _ .. map (drop _ 1) _))
+(define (phase-exports->names exports)
+  (map first
+       (apply append (map (curryr drop 1) exports))))
 
 (define (module->all-exported-names mod)
   (let-values ([(exp-values exp-syntax) (module->exports mod)])
@@ -27,8 +27,8 @@
             (phase-exports->names exp-syntax))))
 
 (define (module->documented-exported-names mod)
-  (filter (has-docs? mod _) (module->all-exported-names mod)))
+  (filter (curry has-docs? mod) (module->all-exported-names mod)))
 
 (define (module->undocumented-exported-names mod)
-  (filter-not (has-docs? mod _)
+  (filter-not (curry has-docs? mod)
               (module->all-exported-names mod)))

--- a/info.rkt
+++ b/info.rkt
@@ -1,8 +1,7 @@
 #lang info
 
 (define collection 'multi)
-(define deps '("compose-app"
-               "reprovide-lang"
+(define deps '("reprovide-lang"
                "base" "rackunit-lib" "scribble-lib" "racket-index"))
 (define build-deps '("scribble-lib"
                      "rackunit-lib"


### PR DESCRIPTION
Hi,

The recent commit 6c4e4e8b86f23696bf06c6da8dafa2f850b39a89 added a dependency on the package `compose-app`, which itself transitively depends on a recent version of `scribble-lib`. This means that `doc-coverage` does not work on Racket v6.3 anymore.

I'm generally not caring much about older versions for research projects — if it compiles, good, if it needs a recent feature of Racket, nevermind. However, `doc-coverage` is the sort of tools which gets used on Travis builds, for example, and `compose-app` seems to be used only in a couple of lines.

Would it make sense to drop the dependency on `compose-app` to regain compatibility with v6.3 (and possibly earlier versions, I haven't checked)?

This patch only restores compatibility with v6.3, not with earlier versions, though.

Note: In my case, I just skipped the installation and execution of `doc-coverage` for v6.3 in my Travis build script, so I a fix is not really needed, but that kind of workaround is a bit annoying to setup, so having broader compatibility may be nice for other developers.

If you prefer to move on to only supporting later versions, of course, feel free to reject this PR (as mentioned above, it's easy enough to skip the installation of doc-coverage in build scripts for older versions).