### PR TITLE
Depend on reprovide-lang-lib, not reprovide-lang

### DIFF
--- a/doc-coverage/info.rkt
+++ b/doc-coverage/info.rkt
@@ -7,7 +7,7 @@
   '(("base" #:version "6.3")
     "racket-index"
     "rackunit-lib"
-    "reprovide-lang"
+    "reprovide-lang-lib"
     "scribble-lib"))
 
 (define build-deps


### PR DESCRIPTION
The `reprovide-lang` package has been split so that the modules are now in `reprovide-lang-lib` and the docs and tests are in `reprovide-lang`.

Related to https://github.com/jackfirth/lens/pull/307