### PR TITLE
Remove expand-for-clause

### DIFF
--- a/doc-coverage/private/raco.rkt
+++ b/doc-coverage/private/raco.rkt
@@ -105,7 +105,7 @@
   (check-equal?
    (with-output-to-string
      (lambda () (system* (find-exe) "-l" "raco" "doc-coverage" "racket/base")))
-   "Module racket/base is missing documentation for: (expand-for-clause for-clause-syntax-protect syntax-pattern-variable?)\n")
+   "Module racket/base is missing documentation for: (for-clause-syntax-protect syntax-pattern-variable?)\n")
   (check-equal?
    (with-output-to-string
      (lambda () (system* (find-exe) "-l" "raco" "doc-coverage" "-r" "0.5" "racket/match")))


### PR DESCRIPTION
Remove expand-for-clause as it's not longer exported by racket/base.

See also: racket/racket#3246
Related to: racket/racket#3300